### PR TITLE
ServiceURL.getLocationURI() need not throw URISyntaxException.

### DIFF
--- a/src/main/java/org/wildfly/discovery/ServiceURL.java
+++ b/src/main/java/org/wildfly/discovery/ServiceURL.java
@@ -233,7 +233,7 @@ public final class ServiceURL extends ServiceDesignation {
         return toServiceURI;
     }
 
-    public URI getLocationURI() throws URISyntaxException {
+    public URI getLocationURI() {
         return uri;
     }
 

--- a/src/main/java/org/wildfly/discovery/impl/StaticDiscoveryProvider.java
+++ b/src/main/java/org/wildfly/discovery/impl/StaticDiscoveryProvider.java
@@ -18,7 +18,6 @@
 
 package org.wildfly.discovery.impl;
 
-import java.net.URISyntaxException;
 import java.util.List;
 
 import org.wildfly.discovery.FilterSpec;
@@ -45,15 +44,12 @@ public final class StaticDiscoveryProvider implements DiscoveryProvider {
         this.services = services;
     }
 
+    @Override
     public DiscoveryRequest discover(final ServiceType serviceType, final FilterSpec filterSpec, final DiscoveryResult result) {
         try {
             for (ServiceURL service : services) {
                 if (serviceType.implies(service) && (filterSpec == null || service.satisfies(filterSpec))) {
-                    try {
-                        result.addMatch(service.getLocationURI());
-                    } catch (URISyntaxException ignored) {
-                        // ignored
-                    }
+                    result.addMatch(service.getLocationURI());
                 }
             }
             return DiscoveryRequest.NULL;


### PR DESCRIPTION
I have a 1st draft of a distributed discovery provider implementation here:
https://github.com/pferraro/wildfly/tree/discovery/clustering/discovery
