### PR TITLE
[WFDISC-22] Fix issue with parsing multiple <service/> elements

### DIFF
--- a/src/main/java/org/wildfly/discovery/DiscoveryXmlParser.java
+++ b/src/main/java/org/wildfly/discovery/DiscoveryXmlParser.java
@@ -297,6 +297,7 @@ final class DiscoveryXmlParser {
                             throw reader.unexpectedElement();
                         }
                     }
+                    break;
                 }
                 case END_ELEMENT: {
                     break out;

--- a/src/test/java/org/wildfly/discovery/FilterSpecTestCase.java
+++ b/src/test/java/org/wildfly/discovery/FilterSpecTestCase.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.*;
 
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -11,10 +12,8 @@ import org.wildfly.discovery.impl.StaticDiscoveryProvider;
 import org.wildfly.discovery.spi.DiscoveryProvider;
 
 import java.net.URI;
-import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Tests for FilterSpec functionality
@@ -104,7 +103,7 @@ public final class FilterSpecTestCase {
                 serviceURL = servicesQueue.takeService();
             } while (serviceURL != null) ;
         } catch (InterruptedException ie) {
-            System.out.println("Discovery was interrupted...");
+            Assert.fail("Discovery was interrupted ...");
         }
         // we should get two result back
         assertEquals(results.size(),2);
@@ -133,7 +132,7 @@ public final class FilterSpecTestCase {
                 serviceURL = servicesQueue.takeService();
             } while (serviceURL != null) ;
         } catch (InterruptedException ie) {
-            System.out.println("Discovery was nterrupted ...");
+            Assert.fail("Discovery was interrupted ...");
         }
         // we should get one results back
         assertEquals(results.size(),1);

--- a/src/test/java/org/wildfly/discovery/ParsingTestCase.java
+++ b/src/test/java/org/wildfly/discovery/ParsingTestCase.java
@@ -1,0 +1,71 @@
+package org.wildfly.discovery;
+
+import junit.framework.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests parsing of discovery configuration files.
+ *
+ * This test does the following:
+ * - uses a wildfly-config.xml file on the classpath to populate ConfiguredProvider with some ServiceURLs
+ * - verifies that the ServiceURLs defined there can be found via discovery
+ *
+ * @author <a href="mailto:rachmato@redhat.com">Richard Achmatowicz</a>
+ */
+public class ParsingTestCase {
+
+    /**
+     * Check that serviceURLs registered in ConfiguredProvider are available
+     */
+    @Test
+    public void testConfiguredProviderContents() {
+
+        // get the default discovery supplier, which should be ConfigiuredProvider
+        Discovery discovery = Discovery.getContextManager().getPrivilegedSupplier().get();
+
+        // ServiceTypes that we defined in the configuration file
+        ServiceType nodeServiceType = new ServiceType("ejb", "jboss", "node:myNode", null);
+        ServiceType URIServiceType = new ServiceType("ejb", "jboss", "http-remoting://15.16.17.18:8080", null);
+
+        // some filter specs to retrieve the SeviceURLs
+        FilterSpec cluster = FilterSpec.equal("cluster","myCluster");
+        FilterSpec node = FilterSpec.equal("node","myNode");
+
+        ServiceType basicServiceType = new ServiceType("ejb", "jboss", null, null);
+
+        // call discovery to retrieve the abstract node we defined
+        List<ServiceURL> nodeResults = new ArrayList<ServiceURL>();
+        try (final ServicesQueue servicesQueue = discovery.discover(basicServiceType, cluster)) {
+            ServiceURL serviceURL = servicesQueue.takeService();
+            while (serviceURL != null) {
+                nodeResults.add(serviceURL);
+                serviceURL = servicesQueue.takeService();
+            }
+        } catch (InterruptedException ie) {
+            Assert.fail("Discovery was interrupted!");
+        }
+        // we should get two result back
+        assertEquals("abstract node was not parsed correctly! ", 1, nodeResults.size());
+        nodeResults.get(0).implies(nodeServiceType);
+
+        // call discovery to retrieve the concrete URI we defined
+        List<ServiceURL> URIResults = new ArrayList<ServiceURL>();
+        try (final ServicesQueue servicesQueue = discovery.discover(basicServiceType, node)) {
+            ServiceURL serviceURL = servicesQueue.takeService();
+            while (serviceURL != null)  {
+                URIResults.add(serviceURL);
+                serviceURL = servicesQueue.takeService();
+            }
+        } catch (InterruptedException ie) {
+            Assert.fail("Discovery was interrupted!");
+        }
+        // we should get two result back
+        assertEquals("concrete node was not parsed correctly! ", 1, URIResults.size());
+        URIResults.get(0).implies(URIServiceType);
+    }
+}

--- a/src/test/resources/wildfly-config.xml
+++ b/src/test/resources/wildfly-config.xml
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<configuration>
+    <discovery xmlns="urn:wildfly-discovery:1.0">
+        <discovery-provider>
+            <static>
+                <service uri="node:myNode" abstract-type="ejb" abstract-type-authority="jboss">
+                    <attribute name="cluster" value="myCluster"/>
+                </service>
+                <service uri="http-remoting://15.16.17.18:8080" abstract-type="ejb" abstract-type-authority="jboss">
+                    <attribute name="node" value="myNode"/>
+                </service>
+            </static>
+        </discovery-provider>
+        <registry-provider>
+            <local-registry/>
+        </registry-provider>
+    </discovery>
+</configuration>


### PR DESCRIPTION
This PR fixes a small problem with parsing multiple <service/> elements in a discovery configuration file.
See: https://issues.jboss.org/browse/WFDISC-22
