### PR TITLE
[WFDISC-24] Add trace logging to discovery calls.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,12 @@
         <version>22</version>
     </parent>
 
+    <properties>
+        <test.level>INFO</test.level>
+    </properties>
+
     <dependencies>
+        <!-- Build dependencies -->
         <dependency>
             <groupId>org.wildfly.common</groupId>
             <artifactId>wildfly-common</artifactId>
@@ -44,12 +49,28 @@
             <version>1.0.0.Beta4</version>
         </dependency>
         <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <version>3.3.0.Final</version>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.modules</groupId>
             <artifactId>jboss-modules</artifactId>
             <version>1.6.0.Beta5</version>
             <optional>true</optional>
             <scope>provided</scope>
         </dependency>
+
+        <!-- Test dependencies -->
+
+        <!-- JBoss logging logmanager-->
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>jboss-logmanager</artifactId>
+            <version>2.0.5.Final</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- JUnit -->
         <dependency>
             <groupId>junit</groupId>
@@ -58,4 +79,27 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemProperties>
+                        <property>
+                            <name>java.util.logging.manager</name>
+                            <value>org.jboss.logmanager.LogManager</value>
+                        </property>
+                        <property>
+                            <name>test.level</name>
+                            <value>${test.level}</value>
+                        </property>
+                    </systemProperties>
+                    <enableAssertions>true</enableAssertions>
+                    <redirectTestOutputToFile>false</redirectTestOutputToFile>
+                    <trimStackTrace>false</trimStackTrace>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/test/java/org/wildfly/discovery/ServiceDesignationTestCase.java
+++ b/src/test/java/org/wildfly/discovery/ServiceDesignationTestCase.java
@@ -37,6 +37,9 @@ public final class ServiceDesignationTestCase {
         assertTrue(ServiceType.of("abstract", "ata").implies(ServiceType.of("abstract", "ata")));
         assertFalse(ServiceType.of("abstract", null).implies(ServiceType.of("abstract", "ata")));
         assertFalse(ServiceType.of("abstract", "ata").implies(ServiceType.of("abstract", null)));
+        assertTrue(ServiceType.of("abstract", "ata").implies(ServiceType.of("abstract", "ata", "foo", "bar")));
+        assertTrue(ServiceType.of("abstract", "ata", "scheme", "scheme-ata").implies(ServiceType.of("abstract", "ata", "scheme", "scheme-ata")));
+        assertFalse(ServiceType.of("abstract", "ata", "scheme", "scheme-ata").implies(ServiceType.of("abstract", "ata", "scheme2", "scheme-ata2")));
     }
 
     @Test

--- a/src/test/resources/logging.properties
+++ b/src/test/resources/logging.properties
@@ -1,0 +1,46 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2010 Red Hat, Inc., and individual contributors
+# as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Additional logger names to configure (root logger is always configured)
+loggers=org.wildfly.discovery
+
+# Root logger configuration
+logger.level=${test.level:INFO}
+logger.handlers=CONSOLE, FILE
+
+logger.org.wildfly.discovery.level=TRACE
+
+# Console handler configuration
+handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
+handler.CONSOLE.properties=autoFlush
+handler.CONSOLE.level=${test.level:DEBUG}
+handler.CONSOLE.autoFlush=true
+handler.CONSOLE.formatter=PATTERN
+
+# File handler configuration
+handler.FILE=org.jboss.logmanager.handlers.FileHandler
+handler.FILE.level=${test.level:DEBUG}
+handler.FILE.properties=autoFlush,fileName
+handler.FILE.autoFlush=true
+handler.FILE.fileName=./target/test.log
+handler.FILE.formatter=PATTERN
+
+# Formatter pattern configuration
+formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+formatter.PATTERN.properties=pattern
+formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n
+


### PR DESCRIPTION
This PR adds some tracing-level logging to each call to discovery.

For more details, see:  https://issues.jboss.org/browse/WFDISC-24