### PR TITLE
[WFDESC-26] Add predicate parameter to discovery calls.

### DIFF
--- a/src/main/java/org/wildfly/discovery/ConfiguredProvider.java
+++ b/src/main/java/org/wildfly/discovery/ConfiguredProvider.java
@@ -23,6 +23,8 @@ import org.wildfly.discovery.spi.DiscoveryRequest;
 import org.wildfly.discovery.spi.DiscoveryResult;
 import org.wildfly.discovery.spi.RegistryProvider;
 
+import java.util.function.Predicate;
+
 final class ConfiguredProvider implements DiscoveryProvider, RegistryProvider {
 
     private final DiscoveryProvider delegateDiscoveryProvider;
@@ -41,8 +43,8 @@ final class ConfiguredProvider implements DiscoveryProvider, RegistryProvider {
         return delegateRegistryProvider.registerService(serviceURL);
     }
 
-    public DiscoveryRequest discover(final ServiceType serviceType, final FilterSpec filterSpec, final DiscoveryResult result) {
-        return delegateDiscoveryProvider.discover(serviceType, filterSpec, result);
+    public DiscoveryRequest discover(final ServiceType serviceType, final FilterSpec filterSpec, final Predicate<ServiceURL> predicate, final DiscoveryResult result) {
+        return delegateDiscoveryProvider.discover(serviceType, filterSpec, predicate, result);
     }
 
     static final ConfiguredProvider INSTANCE = DiscoveryXmlParser.getConfiguredProvider();

--- a/src/main/java/org/wildfly/discovery/Discovery.java
+++ b/src/main/java/org/wildfly/discovery/Discovery.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
 
 import org.jboss.logging.Logger;
 import org.wildfly.common.Assert;
@@ -86,18 +87,19 @@ public final class Discovery implements Contextual<Discovery> {
      * facilitate simple usage in a {@code try}-with-resources block.
      *
      * @param serviceType the abstract or concrete type of service to search for
-     * @param filterSpec the service filter specification
+     * @param filterSpec the service filter specification or (@code null) to return all matches
+     * @param predicate the predicate on ServiceURLs to satisfy or (@code null) to return all matches
      * @return the services queue
      */
-    public ServicesQueue discover(ServiceType serviceType, FilterSpec filterSpec) {
+    public ServicesQueue discover(ServiceType serviceType, FilterSpec filterSpec, Predicate<ServiceURL> predicate) {
         Assert.checkNotNullParam("serviceType", serviceType);
         final LinkedBlockingQueue<ServiceURL> queue = new LinkedBlockingQueue<>();
         final CopyOnWriteArrayList<Throwable> problems = new CopyOnWriteArrayList<>();
         final DiscoveryResult result = new BlockingQueueDiscoveryResult(queue, problems);
 
-        log.tracef("Calling discover(%s, %s) with result instance %s\n", serviceType, (filterSpec == null ? "null" : filterSpec), result);
+        log.tracef("Calling discover(%s, %s, %s) with result instance %s\n", serviceType, (filterSpec == null ? "null" : filterSpec), (predicate == null ? "null" : predicate), result);
 
-        return new BlockingQueueServicesQueue(queue, problems, provider.discover(serviceType, filterSpec, result));
+        return new BlockingQueueServicesQueue(queue, problems, provider.discover(serviceType, filterSpec, predicate, result));
     }
 
     /**

--- a/src/main/java/org/wildfly/discovery/impl/AggregateDiscoveryProvider.java
+++ b/src/main/java/org/wildfly/discovery/impl/AggregateDiscoveryProvider.java
@@ -21,6 +21,7 @@ package org.wildfly.discovery.impl;
 import java.net.URI;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
 
 import org.wildfly.common.Assert;
 import org.wildfly.discovery.FilterSpec;
@@ -49,13 +50,13 @@ public final class AggregateDiscoveryProvider implements DiscoveryProvider {
         this.delegates = delegates;
     }
 
-    public DiscoveryRequest discover(final ServiceType serviceType, final FilterSpec filterSpec, final DiscoveryResult result) {
+    public DiscoveryRequest discover(final ServiceType serviceType, final FilterSpec filterSpec, final Predicate<ServiceURL> predicate, final DiscoveryResult result) {
         final AtomicInteger count = new AtomicInteger(delegates.length);
         final DiscoveryRequest[] delegateRequests = new DiscoveryRequest[delegates.length];
         for (int i = 0, delegatesLength = delegates.length; i < delegatesLength; i++) {
             final DiscoveryProvider delegate = delegates[i];
             if (delegate != null) {
-                delegateRequests[i] = delegate.discover(serviceType, filterSpec, new AggregatingDiscoveryResult(result, count));
+                delegateRequests[i] = delegate.discover(serviceType, filterSpec, predicate, new AggregatingDiscoveryResult(result, count));
             } else {
                 handleComplete(count, result);
             }

--- a/src/main/java/org/wildfly/discovery/impl/LocalRegistryAndDiscoveryProvider.java
+++ b/src/main/java/org/wildfly/discovery/impl/LocalRegistryAndDiscoveryProvider.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
 
 import org.wildfly.common.Assert;
 import org.wildfly.discovery.AggregateServiceRegistration;
@@ -64,14 +65,14 @@ public final class LocalRegistryAndDiscoveryProvider implements RegistryProvider
         return new AggregateHandle(list, array);
     }
 
-    public DiscoveryRequest discover(final ServiceType serviceType, final FilterSpec filterSpec, final DiscoveryResult result) {
+    public DiscoveryRequest discover(final ServiceType serviceType, final FilterSpec filterSpec, final Predicate<ServiceURL> predicate, final DiscoveryResult result) {
         ServiceURL serviceURL;
         for (Handle handle : handles) {
             if (! handle.isOpenAndActive()) {
                 continue;
             }
             serviceURL = handle.getServiceURL();
-            if (serviceType.implies(serviceURL) && serviceURL.satisfies(filterSpec)) {
+            if (serviceType.implies(serviceURL) && (serviceURL == null || serviceURL.satisfies(filterSpec)) && (predicate == null || predicate.test(serviceURL))) {
                 result.addMatch(serviceURL);
             }
         }

--- a/src/main/java/org/wildfly/discovery/impl/MutableDiscoveryProvider.java
+++ b/src/main/java/org/wildfly/discovery/impl/MutableDiscoveryProvider.java
@@ -19,10 +19,12 @@
 package org.wildfly.discovery.impl;
 
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
 
 import org.wildfly.common.Assert;
 import org.wildfly.discovery.FilterSpec;
 import org.wildfly.discovery.ServiceType;
+import org.wildfly.discovery.ServiceURL;
 import org.wildfly.discovery.spi.DiscoveryProvider;
 import org.wildfly.discovery.spi.DiscoveryRequest;
 import org.wildfly.discovery.spi.DiscoveryResult;
@@ -62,7 +64,7 @@ public final class MutableDiscoveryProvider implements DiscoveryProvider {
         delegateRef.set(delegateProvider);
     }
 
-    public DiscoveryRequest discover(final ServiceType serviceType, final FilterSpec filterSpec, final DiscoveryResult result) {
-        return delegateRef.get().discover(serviceType, filterSpec, result);
+    public DiscoveryRequest discover(final ServiceType serviceType, final FilterSpec filterSpec, final Predicate<ServiceURL> predicate, final DiscoveryResult result) {
+        return delegateRef.get().discover(serviceType, filterSpec, predicate, result);
     }
 }

--- a/src/main/java/org/wildfly/discovery/impl/StaticDiscoveryProvider.java
+++ b/src/main/java/org/wildfly/discovery/impl/StaticDiscoveryProvider.java
@@ -19,6 +19,7 @@
 package org.wildfly.discovery.impl;
 
 import java.util.List;
+import java.util.function.Predicate;
 
 import org.wildfly.discovery.FilterSpec;
 import org.wildfly.discovery.ServiceType;
@@ -45,10 +46,10 @@ public final class StaticDiscoveryProvider implements DiscoveryProvider {
     }
 
     @Override
-    public DiscoveryRequest discover(final ServiceType serviceType, final FilterSpec filterSpec, final DiscoveryResult result) {
+    public DiscoveryRequest discover(final ServiceType serviceType, final FilterSpec filterSpec, final Predicate<ServiceURL> predicate, final DiscoveryResult result) {
         try {
             for (ServiceURL service : services) {
-                if (serviceType.implies(service) && (filterSpec == null || service.satisfies(filterSpec))) {
+                if (serviceType.implies(service) && (filterSpec == null || service.satisfies(filterSpec)) && (predicate == null || predicate.test(service)) ) {
                     result.addMatch(service);
                 }
             }

--- a/src/main/java/org/wildfly/discovery/spi/DiscoveryProvider.java
+++ b/src/main/java/org/wildfly/discovery/spi/DiscoveryProvider.java
@@ -22,6 +22,8 @@ import org.wildfly.discovery.FilterSpec;
 import org.wildfly.discovery.ServiceType;
 import org.wildfly.discovery.ServiceURL;
 
+import java.util.function.Predicate;
+
 /**
  * A discovery provider.  This interface is implemented by all discovery provider implementations.
  *
@@ -42,14 +44,15 @@ public interface DiscoveryProvider {
      *
      * @param serviceType the service type to match
      * @param filterSpec the service attribute filter expression, or {@code null} to return all matches
+     * @param predicate the predicate on ServiceURLs to satisfy or (@code null) to return all matches
      * @param result the discovery result
      */
-    DiscoveryRequest discover(ServiceType serviceType, FilterSpec filterSpec, DiscoveryResult result);
+    DiscoveryRequest discover(ServiceType serviceType, FilterSpec filterSpec, Predicate<ServiceURL> predicate, DiscoveryResult result);
 
     /**
      * The empty discovery provider.
      */
-    DiscoveryProvider EMPTY = (serviceType, filterSpec, result) -> {
+    DiscoveryProvider EMPTY = (serviceType, filterSpec, predicate, result) -> {
         result.complete();
         return DiscoveryRequest.NULL;
     };

--- a/src/test/java/org/wildfly/discovery/ParsingTestCase.java
+++ b/src/test/java/org/wildfly/discovery/ParsingTestCase.java
@@ -29,8 +29,8 @@ public class ParsingTestCase {
         Discovery discovery = Discovery.getContextManager().getPrivilegedSupplier().get();
 
         // ServiceTypes that we defined in the configuration file
-        ServiceType nodeServiceType = new ServiceType("ejb", "jboss", "node:myNode", null);
-        ServiceType URIServiceType = new ServiceType("ejb", "jboss", "http-remoting://15.16.17.18:8080", null);
+        ServiceType nodeServiceType = new ServiceType("ejb", "jboss", "node", null);
+        ServiceType URIServiceType = new ServiceType("ejb", "jboss", "http-remoting", null);
 
         // some filter specs to retrieve the SeviceURLs
         FilterSpec cluster = FilterSpec.equal("cluster","myCluster");
@@ -40,12 +40,8 @@ public class ParsingTestCase {
 
         // call discovery to retrieve the abstract node we defined
         List<ServiceURL> nodeResults = new ArrayList<ServiceURL>();
-        try (final ServicesQueue servicesQueue = discovery.discover(basicServiceType, cluster)) {
-            ServiceURL serviceURL = servicesQueue.takeService();
-            while (serviceURL != null) {
-                nodeResults.add(serviceURL);
-                serviceURL = servicesQueue.takeService();
-            }
+        try (final ServicesQueue servicesQueue = discovery.discover(basicServiceType, cluster, serviceURL -> true)) {
+            Utils.drainServicesQueue(servicesQueue, nodeResults);
         } catch (InterruptedException ie) {
             Assert.fail("Discovery was interrupted!");
         }
@@ -55,12 +51,8 @@ public class ParsingTestCase {
 
         // call discovery to retrieve the concrete URI we defined
         List<ServiceURL> URIResults = new ArrayList<ServiceURL>();
-        try (final ServicesQueue servicesQueue = discovery.discover(basicServiceType, node)) {
-            ServiceURL serviceURL = servicesQueue.takeService();
-            while (serviceURL != null)  {
-                URIResults.add(serviceURL);
-                serviceURL = servicesQueue.takeService();
-            }
+        try (final ServicesQueue servicesQueue = discovery.discover(basicServiceType, node, serviceURL -> true)) {
+            Utils.drainServicesQueue(servicesQueue, URIResults);
         } catch (InterruptedException ie) {
             Assert.fail("Discovery was interrupted!");
         }

--- a/src/test/java/org/wildfly/discovery/Utils.java
+++ b/src/test/java/org/wildfly/discovery/Utils.java
@@ -1,0 +1,86 @@
+package org.wildfly.discovery;
+
+import org.wildfly.common.Assert;
+
+import java.net.URI;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *
+ * Created by nrla on 16/06/17.
+ */
+public class Utils {
+
+    public Utils() {
+    }
+
+    public static List<ServiceURL> drainServicesQueue(ServicesQueue discoveryCallServicesQueue) throws InterruptedException {
+        List<ServiceURL> results = new ArrayList<ServiceURL>();
+        drainServicesQueue(discoveryCallServicesQueue, results);
+        return results;
+    }
+
+    public static void drainServicesQueue(ServicesQueue servicesQueue,List<ServiceURL> serviceURLs) throws InterruptedException {
+        Assert.checkNotNullParam("servicesQueue", servicesQueue);
+        Assert.checkNotNullParam("servicesURLs", serviceURLs);
+
+        try {
+            ServiceURL serviceURL = servicesQueue.takeService();
+            do {
+                serviceURLs.add(serviceURL);
+                serviceURL = servicesQueue.takeService();
+            } while (serviceURL != null);
+        } catch(InterruptedException ie) {
+            throw ie;
+        }
+    }
+
+    /**
+     * Builds ServiceURLs with constant default type and varying attributes.
+     *
+     * @param abstractType the abstract service type (must not be (@code null))
+     * @param abstractTypeAuth the abstract service type authority (must not be (@code null))
+     * @param pairs one or more attribute pairs to be set in the ServiceURL (must not be (@code null))
+     *
+     * @return a configured ServiceURL
+     * @throws Exception
+     */
+    public static ServiceURL buildServiceURL(String abstractType, String abstractTypeAuth, URI uri, AttributeValuePair...pairs) throws Exception {
+        Assert.checkNotNullParam("abstractType", abstractType);
+        Assert.checkNotNullParam("abstractTypeAuth", abstractTypeAuth);
+        Assert.checkNotNullParam("uri", uri);
+
+        final ServiceURL.Builder builder = new ServiceURL.Builder();
+        // set the locationURI
+        builder.setUri(uri);
+        builder.setAbstractType(abstractType);
+        builder.setAbstractTypeAuthority(abstractTypeAuth);
+        // add an attribute
+        for (AttributeValuePair pair : pairs) {
+            builder.addAttribute(pair.getAttribute(), AttributeValue.fromString(pair.getValue()));
+        }
+        return builder.create();
+    }
+
+    /**
+     * An attribute value pair
+     */
+    public static class AttributeValuePair {
+        String attribute = null;
+        String value = null;
+
+        public AttributeValuePair(String attribute, String value) {
+            this.attribute = attribute;
+            this.value = value;
+        }
+        public String getAttribute() {
+            return attribute;
+        }
+        public String getValue() {
+            return value;
+        }
+    }
+
+}


### PR DESCRIPTION
This PR does the following:
* adds a `Predicate<ServiceURL>` parameter to discovery calls to allow filtering discovery results by arbitrary predicates on ServiceURLs
* adds a Utils class for collecting together shared test case utilities

For details: see https://issues.jboss.org/browse/WFDISC-26