### PR TITLE
WFDISC-33 Serializing FilterSpec using JBoss Marshalling causes StackOverflowError.

### DIFF
--- a/src/main/java/org/wildfly/discovery/FilterSpec.java
+++ b/src/main/java/org/wildfly/discovery/FilterSpec.java
@@ -739,7 +739,7 @@ public abstract class FilterSpec implements Serializable {
         return new Serialized(toString());
     }
 
-    class Serialized implements Serializable {
+    static class Serialized implements Serializable {
 
         private static final long serialVersionUID = 555689132344539984L;
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFDISC-33