### PR TITLE
[WFDISC-36] API for lazy discovery

### DIFF
--- a/src/main/java/org/wildfly/discovery/ConfiguredProvider.java
+++ b/src/main/java/org/wildfly/discovery/ConfiguredProvider.java
@@ -23,6 +23,8 @@ import org.wildfly.discovery.spi.DiscoveryRequest;
 import org.wildfly.discovery.spi.DiscoveryResult;
 import org.wildfly.discovery.spi.RegistryProvider;
 
+import java.net.URI;
+
 final class ConfiguredProvider implements DiscoveryProvider, RegistryProvider {
 
     private final DiscoveryProvider delegateDiscoveryProvider;
@@ -43,6 +45,10 @@ final class ConfiguredProvider implements DiscoveryProvider, RegistryProvider {
 
     public DiscoveryRequest discover(final ServiceType serviceType, final FilterSpec filterSpec, final DiscoveryResult result) {
         return delegateDiscoveryProvider.discover(serviceType, filterSpec, result);
+    }
+
+    public void processMissingTarget(URI location, Exception cause) {
+        delegateDiscoveryProvider.processMissingTarget(location, cause);
     }
 
     static final ConfiguredProvider INSTANCE = DiscoveryXmlParser.getConfiguredProvider();

--- a/src/main/java/org/wildfly/discovery/Discovery.java
+++ b/src/main/java/org/wildfly/discovery/Discovery.java
@@ -137,6 +137,10 @@ public final class Discovery implements Contextual<Discovery> {
         return discover(description.getServiceType(), description.getFilterSpec());
     }
 
+    public void processMissingTarget(URI location, Exception cause){
+        provider.processMissingTarget(location, cause);
+    }
+
     /**
      * Create a discovery object with the given providers.  The given {@code providers} argument and its array
      * elements may not be {@code null}.

--- a/src/main/java/org/wildfly/discovery/impl/AggregateDiscoveryProvider.java
+++ b/src/main/java/org/wildfly/discovery/impl/AggregateDiscoveryProvider.java
@@ -69,6 +69,14 @@ public final class AggregateDiscoveryProvider implements DiscoveryProvider {
         }
     }
 
+    public void processMissingTarget(URI location, Exception cause) {
+        for (DiscoveryProvider delegate : delegates) {
+            if (delegate != null) {
+                delegate.processMissingTarget(location, cause);
+            }
+        }
+    }
+
     static class AggregatingDiscoveryRequest implements DiscoveryRequest {
         private final DiscoveryRequest[] delegateRequests;
 

--- a/src/main/java/org/wildfly/discovery/spi/DiscoveryProvider.java
+++ b/src/main/java/org/wildfly/discovery/spi/DiscoveryProvider.java
@@ -22,6 +22,8 @@ import org.wildfly.discovery.FilterSpec;
 import org.wildfly.discovery.ServiceType;
 import org.wildfly.discovery.ServiceURL;
 
+import java.net.URI;
+
 /**
  * A discovery provider.  This interface is implemented by all discovery provider implementations.
  *
@@ -45,6 +47,16 @@ public interface DiscoveryProvider {
      * @param result the discovery result
      */
     DiscoveryRequest discover(ServiceType serviceType, FilterSpec filterSpec, DiscoveryResult result);
+
+    /**
+     * This method is invoked on provider if the invocation using discovered URI was not successful. This method is
+     * supposed to be used by lazy discovery algorithms. By default, it is set to empty method so it could be skipped
+     * by providers implementing polling algorithms.
+     * @param location location on which invocations has failed
+     * @param cause the cause of the failure
+     */
+    default void processMissingTarget(URI location, Exception cause) {
+    }
 
     /**
      * The empty discovery provider.


### PR DESCRIPTION
Sample implementation in:
https://github.com/tadamski/wildfly-http-client/tree/WEJBHTTP-34-api

I'm adding this API to be able to implement algorithms not based on polling. I think it is necessary for HTTP based discovery - one of the reasons would be that HTTP-over-EJB is cluster agnostic by design. Furthermore, this API maybe useful to provide alternative discovery algorithms.