### PR TITLE
WFDISC-48 Remove the obsolete use of junit.framework.Assert

### DIFF
--- a/src/test/java/org/wildfly/discovery/ParsingTestCase.java
+++ b/src/test/java/org/wildfly/discovery/ParsingTestCase.java
@@ -1,12 +1,12 @@
 package org.wildfly.discovery;
 
-import junit.framework.Assert;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * Tests parsing of discovery configuration files.


### PR DESCRIPTION
https://issues.redhat.com/browse/WFDISC-48