### PR TITLE
[WFDISC-54] Do not cancel DiscoveryAttempt connection creation if oth…

### DIFF
--- a/src/main/java/org/wildfly/discovery/Discovery.java
+++ b/src/main/java/org/wildfly/discovery/Discovery.java
@@ -292,9 +292,6 @@ public final class Discovery implements Contextual<Discovery> {
         }
 
         public void close() {
-            if (! isFinished()) {
-                request.cancel();
-            }
         }
 
         @NotNull


### PR DESCRIPTION
…er node has provided the result already

@dmlloyd
I'm opening this PR as a follow up to discussion in https://github.com/wildfly/wildfly-discovery/pull/68:
* I have just modified the close method, but I don't believe removing cancellation handlers is appropriate as there possibly may be some other trigger for cancellation and that has to be taken into account
* Removing cancellation fixes the intial problem in WFTC-53
* I have also run wildfly integration tests to double check if this removal causes some unanticipated problem but all seems fine
* I was concerned whether this change may lead to attempts of many connection creation if there are some problems with connection establishment but looking at ClientServiceHandle [code](https://github.com/jboss-remoting/jboss-remoting/blob/main/src/main/java/org/jboss/remoting3/ClientServiceHandle.java#L70) imho this should work fine as well.
